### PR TITLE
Get progress from `request.upload.onprogress` as well.

### DIFF
--- a/addon/system/http-request.js
+++ b/addon/system/http-request.js
@@ -82,6 +82,10 @@ export default function () {
     this.onprogress(evt);
   });
 
+  if (request.upload) {
+    request.upload.onprogress = request.onprogress;
+  }
+
   request.onload = bind(this, function () {
     let response = parseResponse(request);
     if (Math.floor(response.status / 200) === 1) {


### PR DESCRIPTION
In order to get upload progress the handler must be attached to
`request.upload.onprogress`.

See:
https://developer.mozilla.org/en-US/docs/Using_files_from_web_applications