### PR TITLE
Fix fastboot guard for IE11

### DIFF
--- a/addon/components/file-dropzone/component.js
+++ b/addon/components/file-dropzone/component.js
@@ -10,7 +10,7 @@ const { service } = Ember.inject;
 const DATA_TRANSFER = 'DATA_TRANSFER' + uuid.short();
 
 let supported = (function () {
-  return window.hasOwnProperty('document') &&
+  return typeof window !== 'undefined' && window.document &&
          'draggable' in document.createElement('span');
 }());
 


### PR DESCRIPTION
https://github.com/tim-evans/ember-file-upload/pull/22 makes drag & drop work for me on IE11. But `dropzone.supported` is incorrectly calculated as `false`.

This happens because on IE11, `window.hasOwnProperty('document')` is false.