### PR TITLE
Add testing support to file-upload onchange action

### DIFF
--- a/addon/components/file-upload/component.js
+++ b/addon/components/file-upload/component.js
@@ -1,6 +1,7 @@
 import Ember from 'ember';
 import layout from './template';
 import uuid from '../../system/uuid';
+const { testing } = Ember;
 
 const { get, computed, setProperties, getProperties } = Ember;
 const { service } = Ember.inject;
@@ -59,7 +60,8 @@ export default Ember.Component.extend({
   },
 
   actions: {
-    change(files) {
+    change(event) {
+      const files = testing ? event.testingFiles : event.target.files;
       get(this, 'queue')._addFiles(files, 'browse');
     }
   }

--- a/addon/components/file-upload/template.hbs
+++ b/addon/components/file-upload/template.hbs
@@ -1,2 +1,2 @@
-<input id={{for}} type="file" accept={{accept}} multiple={{multiple}} onchange={{action "change" value="target.files"}} style="display: none;" />
+<input id={{for}} type="file" accept={{accept}} multiple={{multiple}} onchange={{action "change"}} style="display: none;" />
 {{yield}}


### PR DESCRIPTION
Sending through the entire event to the action allows for fake files to
be injected when testing. See these links for more info:

https://github.com/emberjs/ember.js/issues/13540#issuecomment-220849954
https://medium.com/@chrisdmasters/acceptance-testing-file-uploads-in-ember-2-5-1c9c8dbe5368