### PR TITLE
Do not call set on a destroyed object

### DIFF
--- a/addon/components/file-dropzone/component.js
+++ b/addon/components/file-dropzone/component.js
@@ -79,7 +79,9 @@ export default Ember.Component.extend({
       this.ondragleave(this[DATA_TRANSFER]);
       this[DATA_TRANSFER] = null;
     }
-    set(this, 'active', false);
+    if (!this.isDestroyed) {
+      set(this, 'active', false);
+    }
   },
 
   didDragOver(evt) {


### PR DESCRIPTION
Hey Tim, 

Ran into a bug with the global uploader today.

Pretty much to reproduce 
1. Go to an article page 
2. Upload via `global uploader` to a photosTout
3. Try to upload another asset via `global uploader`.
4. Hover over any remaining upload area

This will throw a bunch of errors 

From my understanding since the photosTout has an asset added and can no longer be added to via `global uploader` the `upload to photoTout` section is destroyed. However, since your refactor of the ember-file-upload code to now keep one massive reference to all drop areas, the `set` on line 82 is being called for the drop area that has been removed from the DOM (the `upload to photoTout` section). 