### PR TITLE
Permit setting withCredentials on the XMLHttpRequest for file-upload

### DIFF
--- a/addon/file.js
+++ b/addon/file.js
@@ -45,6 +45,8 @@ function normalizeOptions(file, url, options) {
 
   options.data[options.fileKey] = file.blob;
 
+  options.withCredentials = options.withCredentials || false;
+
   return options;
 }
 
@@ -216,7 +218,10 @@ export default Ember.Object.extend({
       }
     });
 
-    let request = new HTTPRequest({ label: `${options.method} ${get(this, 'name') } to ${options.url}` });
+    let request = new HTTPRequest({
+      withCredentials: options.withCredentials,
+      label: `${options.method} ${get(this, 'name') } to ${options.url}`
+    });
     request.open(options.method, options.url);
 
     Object.keys(options.headers).forEach(function (key) {

--- a/addon/system/http-request.js
+++ b/addon/system/http-request.js
@@ -51,6 +51,8 @@ export default function (options = {}) {
   let { resolve, reject, promise } = RSVP.defer(`ember-file-upload: ${options.label}`);
   let request = new XMLHttpRequest();
 
+  request.withCredentials = options.withCredentials;
+
   let aborted;
   promise.cancel = () => {
     if (aborted == null) {

--- a/tests/unit/system/http-request-test.js
+++ b/tests/unit/system/http-request-test.js
@@ -149,6 +149,18 @@ test('successful send with a text/xml response', function (assert) {
   });
 });
 
+test(`succesful open with 'withCredentials: true'`, function (assert) {
+  this.subject = new HttpRequest({withCredentials: true});
+  this.subject.open('POST', 'http://emberjs.com');
+
+  assert.equal(this.request.withCredentials, true);
+});
+
+test(`confirm withCredentials: undefined by default`, function (assert) {
+  this.subject.open('POST', 'http://emberjs.com');
+  assert.equal(this.request.withCredentials, undefined);
+});
+
 skip('onprogress', function () {
 
 });


### PR DESCRIPTION
Right now there is no way that I can tell of setting `withCredentials: true` on the file upload, making it difficult to pass a session cookie through for authentication. This commit allows you to set `withCredentials: true` on the `options` object when calling `file.upload`.