### PR TITLE
'disabled' attribute for file-upload

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ exposes a variety of parameters for configuring file-uploader:
 |---------------------|------------------|
 | `accept`            | a list of MIME types / extensions to accept by the input
 | `multiple`          | whether multiple files can be selected
+| `disabled`          | if set, disables input and prevents files from being added to the queue
 | `onfileadd`         | the name of the action to be called when a file is added to a queue
 
 The `{{file-dropzone}}` component:

--- a/addon/components/file-upload/component.js
+++ b/addon/components/file-upload/component.js
@@ -32,7 +32,7 @@ export default Ember.Component.extend({
 
   didReceiveAttrs() {
     if (get(this, 'queue')) {
-      setProperties(get(this, 'queue'), getProperties(this, 'accept', 'multiple', 'onfileadd'));
+      setProperties(get(this, 'queue'), getProperties(this, 'accept', 'multiple', 'disabled', 'onfileadd'));
     }
   },
 

--- a/addon/components/file-upload/template.hbs
+++ b/addon/components/file-upload/template.hbs
@@ -1,2 +1,2 @@
-<input id={{for}} type="file" accept={{accept}} multiple={{multiple}} onchange={{action "change" value="target.files"}} style="display: none;" />
+<input id={{for}} type="file" accept={{accept}} multiple={{multiple}} disabled={{disabled}} onchange={{action "change" value="target.files"}} style="display: none;" />
 {{yield}}

--- a/addon/queue.js
+++ b/addon/queue.js
@@ -56,18 +56,21 @@ export default Ember.Object.extend({
    */
   _addFiles(fileList, source) {
     let onfileadd = get(this, 'onfileadd');
+    let disabled = get(this, 'disabled');
     let files = [];
 
-    for (let i = 0, len = fileList.length || fileList.size; i < len; i++) {
-      let fileBlob = fileList.item ? fileList.item(i) : fileList[i];
-      if (fileBlob instanceof Blob) {
-        let file = File.fromBlob(fileBlob, source);
+    if (!disabled) {
+      for (let i = 0, len = fileList.length || fileList.size; i < len; i++) {
+        let fileBlob = fileList.item ? fileList.item(i) : fileList[i];
+        if (fileBlob instanceof Blob) {
+          let file = File.fromBlob(fileBlob, source);
 
-        files.push(file);
-        this.push(file);
+          files.push(file);
+          this.push(file);
 
-        if (onfileadd) {
-          next(onfileadd, file);
+          if (onfileadd) {
+            next(onfileadd, file);
+          }
         }
       }
     }


### PR DESCRIPTION
Closes #35.

This PR adds a new file-upload attribute, `disabled`, that if set, does two things:
- Prevents files from being added to the queue*
- Disables the `input` control (the upload button/link/whatnot).

*As a note, the queue can still be manually manipulated in code, e.g. `queue.push(file)`; this only affects the built-in behavior (i.e. `queue._addFile`, which the dropzone uses).

No tests, unfortunately (because of #36), but I did `yarn link` it to my own Ember app and ensure it works as expected. Docs included, at least.

Additional stuff like applying CSS styles is left as an exercise for the user. This just takes care of the core bits that can't be handled in a higher-level custom component.