### PR TITLE
fix(file): file.upload() returns a promise

### DIFF
--- a/addon/file.js
+++ b/addon/file.js
@@ -270,7 +270,7 @@ export default Ember.Object.extend({
   },
 
   upload(url, opts) {
-    upload(this, url, opts, (request, options) => {
+    return upload(this, url, opts, (request, options) => {
       // Build the form
       let form = new FormData();
 


### PR DESCRIPTION
`file.upload()` broke in https://github.com/tim-evans/ember-file-upload/commit/aabc6e8231549ba636bad13c3770d72a8609daaf and was returning `undefined` instead of a promise.