### PR TITLE
Add ability to upload same file twice in a row

### DIFF
--- a/addon/components/file-upload/component.js
+++ b/addon/components/file-upload/component.js
@@ -170,6 +170,7 @@ export default Ember.Component.extend({
   actions: {
     change(files) {
       get(this, 'queue')._addFiles(files, 'browse');
+      this.$().children('input').val(null);
     }
   }
 });


### PR DESCRIPTION
Fixes issue #41 

We tried writing an integration test for the component, but we couldn't find a good way to test this because:

- You can't set the value of a file input programmatically for security reasons - so we can't test that we're setting the value. 

- This is a symptom of the browser not triggering an event from user input, so simulated events do not replicate the issue - so we don't have a way to verify that this allows the event to be triggered a second time. 