### PR TITLE
Fix for #42 -- Changed logic on file type array

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,6 +16,7 @@
 npm-debug.log*
 yarn-error.log
 testem.log
+.idea
 
 # ember-try
 .node_modules.ember-try/

--- a/addon/system/drag-listener.js
+++ b/addon/system/drag-listener.js
@@ -91,7 +91,7 @@ export default class {
 
   getEventSource(evt) {
     let types = evt.dataTransfer.types || [];
-    let areAllTypesFiles = false;
+    let areSomeTypesFiles = false;
     for (let i = 0, len = types.length; i < len; i++) {
       if (types[i] === 'Files' ||
           types[i] === 'application/x-moz-file') {
@@ -99,7 +99,7 @@ export default class {
         break;
       }
     }
-    return areAllTypesFiles ? 'os' : 'web';
+    return areSomeTypesFiles ? 'os' : 'web';
   }
 
   dragenter(evt) {

--- a/addon/system/drag-listener.js
+++ b/addon/system/drag-listener.js
@@ -95,7 +95,7 @@ export default class {
     for (let i = 0, len = types.length; i < len; i++) {
       if (types[i] === 'Files' ||
           types[i] === 'application/x-moz-file') {
-        areAllTypesFiles = true;
+        areSomeTypesFiles = true;
         break;
       }
     }

--- a/addon/system/drag-listener.js
+++ b/addon/system/drag-listener.js
@@ -91,11 +91,11 @@ export default class {
 
   getEventSource(evt) {
     let types = evt.dataTransfer.types || [];
-    let areAllTypesFiles = true;
+    let areAllTypesFiles = false;
     for (let i = 0, len = types.length; i < len; i++) {
-      if (types[i] !== 'Files' &&
-          types[i] !== 'application/x-moz-file') {
-        areAllTypesFiles = false;
+      if (types[i] === 'Files' ||
+          types[i] === 'application/x-moz-file') {
+        areAllTypesFiles = true;
         break;
       }
     }


### PR DESCRIPTION
@tim-evans This is somewhat questionable, because I don't really know what I'm doing or what the total implications of this PR is. This fixes #42.

The value of the `<event>.dataTransfer.types` property for Firefox/Chrome is `[Files]` or `[application/x-moz-file, Files]`.

Helpfully, safari (my 11.0.1 running MacOS 10.13.1) provides us with a lot more (seemingly useless) data: 

```js
["public.file-url", "CorePasteboardFlavorType 0x6675726C", "dyn.ah62d4rv4gu8y6y4grf0gn5xbrzw1gydcr7u1e3cytf2gn", "text/uri-list", "Files", "dyn.ah62d4rv4gu8yc6durvwwaznwmuuha2pxsvw0e55bsmwca7d3sbwu", "com.apple.finder.node"]
```

Here's a JSBin i got from the MDN docs: https://jsbin.com/desoviteso/edit?js,console,output

This PR just reverses the logic of `DragListener.getEventSource()` to check to see if "Files" is ever present in the array. 

I really have no idea what the downstream impacts of this may be, and I really can't figure out in what cases this would fail, or if it it passes when it shouldn't. I really have no idea how to write a test for this at all as well...

