### PR TITLE
fix upload promise not being cancellable

### DIFF
--- a/addon/system/http-request.js
+++ b/addon/system/http-request.js
@@ -62,6 +62,12 @@ export default function (options = {}) {
     }
     return aborted.promise;
   };
+  promise.then = function(...args) {
+    let newPromise = RSVP.Promise.prototype.then.apply(this, args);
+    newPromise.cancel = promise.cancel;
+    newPromise.then = promise.then;
+    return newPromise;
+  };
   request.onabort = bind(this, function () {
     this.onabort();
     aborted.resolve();

--- a/tests/unit/system/http-request-test.js
+++ b/tests/unit/system/http-request-test.js
@@ -161,6 +161,19 @@ test(`confirm withCredentials: undefined by default`, function (assert) {
   assert.equal(this.request.withCredentials, undefined);
 });
 
+test('promise is cancellable', function (assert) {
+  this.subject.open('PUT', 'http://emberjs.com');
+  let promise = this.subject.send();
+  assert.ok(typeof promise.cancel === 'function', 'returned promise should have a cancel() method');
+
+  let promise2 = promise
+    .then(function() { })
+    .catch(function() { })
+    .finally(function() { });
+
+  assert.ok(typeof promise2.cancel === 'function', 'chained promise should have a cancel() method');
+});
+
 skip('onprogress', function () {
 
 });


### PR DESCRIPTION
The promise returned from `upload()` wasn't actually cancellable

related to #59 #60