### PR TITLE
Fix acceptance tests APIs

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,24 +135,25 @@ In addition to the file list, there are properties that indicate how many bytes 
 import { upload } from 'ember-file-upload/mirage';
 
 export default function () {
-  this.post('/photos/new', upload(function (db, file) {
+  this.post('/photos/new', upload(function ({ db }, request, file) {
     let { name: filename, size: filesize, url } = file;
-    let photo = db.create('photo', { filename, filesize, url, uploadedAt: new Date() });
-    return photo;
+    return db.create('photo', { filename, filesize, url, uploadedAt: new Date() });
   }));
 }
 ```
 
 ```javascript
 import { upload } from '../../helpers/upload';
-import File from 'ember-file-upload/file';
+import { dataUrlToBlob } from 'ember-file-upload/file';
 
 moduleForAcceptance('/photos');
 
 test('uploading an image', async function (assert) {
-  let file = File.fromDataURL('data:image/gif;base64,R0lGODdhCgAKAIAAAAEBAf///ywAAAAACgAKAAACEoyPBhp7vlySqVVFL8oWg89VBQA7');
-
-  await upload('#upload-photo', file, 'smile.gif');
+  
+  let blob = dataUrlToBlob('data:image/gif;base64,R0lGODdhCgAKAIAAAAEBAf///ywAAAAACgAKAAACEoyPBhp7vlySqVVFL8oWg89VBQA7');
+  let file = new File([ blob ], 'smile.gif');
+  
+  await upload('#upload-photo', file);
 
   let photo = server.db.photos[0];
   assert.equal(photo.filename, 'smile.gif');
@@ -162,14 +163,14 @@ test('uploading an image', async function (assert) {
 If the file isn't uploaded to the server, you don't need to use the mirage helper. The same approach applies to all types of files; encode them as a Base64 data url or read them from a file as a blob.
 
 ```javascript
-import upload from '../helpers/upload';
+import { upload } from '../helpers/upload';
 
 moduleForAcceptance('/notes');
 
 test('showing a note', async function (assert) {
-  let file = File.fromDataUrl('data:text/plain;base64,SSBjYW4gZmVlbCB0aGUgbW9uZXkgbGVhdmluZyBteSBib2R5');
+  let file = new File([ 'I can feel the money leaving my body' ], 'douglas_coupland.txt')
 
-  await upload('#upload-note', file, 'douglas_coupland.txt');
+  await upload('#upload-note', file);
 
   assert.equal(find('.note').text(), 'I can feel the money leaving my body');
 });

--- a/addon/file.js
+++ b/addon/file.js
@@ -8,6 +8,20 @@ import uuid from './system/uuid';
 const { computed, get, set } = Ember;
 const { reads } = computed;
 
+export function dataUrlToBlob(dataURL) {
+  let [typeInfo, base64String] = dataURL.split(',');
+  let mimeType = typeInfo.match(/:(.*?);/)[1];
+
+  let binaryString = atob(base64String);
+  let binaryData = new Uint8Array(binaryString.length);
+
+  for (let i = 0, len = binaryString.length; i < len; i++) {
+    binaryData[i] = binaryString.charCodeAt(i);
+  }
+
+  return new Blob([binaryData], { type: mimeType });
+}
+
 function normalizeOptions(file, url, options) {
   if (typeof url === 'object') {
     options = url;
@@ -345,18 +359,6 @@ export default Ember.Object.extend({
     @return {File} A file object
    */
   fromDataURL(dataURL, source='data-url') {
-    let [typeInfo, base64String] = dataURL.split(',');
-    let mimeType = typeInfo.match(/:(.*?);/)[1];
-
-    let binaryString = atob(base64String);
-    let binaryData = new Uint8Array(binaryString.length);
-
-    for (let i = 0, len = binaryString.length; i < len; i++) {
-      binaryData[i] = binaryString.charCodeAt(i);
-    }
-
-    let blob = new Blob([binaryData], { type: mimeType });
-
-    return this.fromBlob(blob, source);
+    return this.fromBlob(dataUrlToBlob(dataURL, source), source);
   }
 });

--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
     "ember-disable-prototype-extensions": "^1.1.2",
     "ember-engines": "^0.5.8",
     "ember-load-initializers": "^1.0.0",
+    "ember-maybe-import-regenerator-for-testing": "^1.0.0",
     "ember-resolver": "^4.0.0",
     "ember-route-action-helper": "2.0.0",
     "ember-source": "~2.15.0",

--- a/test-support/helpers/upload.js
+++ b/test-support/helpers/upload.js
@@ -1,9 +1,8 @@
 /*global triggerEvent, find */
 
-export default function (selector, file, filename) {
-  let input = findWithAssert(selector)[0];
-
-  file.name = filename;
+export function upload(selector, file) {
+  let upload = find(selector).closest('.file-upload');
+  let input = findWithAssert('input[type=file]', upload)[0];
 
   // This hack is here since we can't mock out the
   // FileList API easily; we're taking advantage
@@ -15,5 +14,5 @@ export default function (selector, file, filename) {
   };
   input.files.size = files.length;
 
-  return triggerEvent(selector, 'change');
+  return triggerEvent(input, 'change');
 }

--- a/tests/.eslintrc.js
+++ b/tests/.eslintrc.js
@@ -1,5 +1,8 @@
 module.exports = {
   env: {
     embertest: true
+  },
+  globals: {
+    server: true
   }
 };

--- a/tests/acceptance/mirage-helpers-test.js
+++ b/tests/acceptance/mirage-helpers-test.js
@@ -1,0 +1,19 @@
+import { test } from 'qunit';
+import moduleForAcceptance from '../../tests/helpers/module-for-acceptance';
+import { upload } from '../helpers/upload';
+import { dataUrlToBlob } from "ember-file-upload/file";
+
+moduleForAcceptance('Acceptance | mirage helpers');
+
+test('upload a photo', async function(assert) {
+  await visit('/');
+
+  let blob = dataUrlToBlob('data:image/gif;base64,R0lGODdhCgAKAIAAAAEBAf///ywAAAAACgAKAAACEoyPBhp7vlySqVVFL8oWg89VBQA7');
+  let file = new File([ blob ], 'smile.gif');
+
+  await upload('#upload-photo', file);
+
+  let photo = server.db.photos[0];
+  assert.ok(photo);
+  assert.equal(photo.filename, 'smile.gif');
+});

--- a/tests/dummy/app/index/template.hbs
+++ b/tests/dummy/app/index/template.hbs
@@ -56,7 +56,7 @@
                            multiple=true
                            onfileadd=(route-action "uploadProof")
                            accept="image/*,video/*,audio/*"}}
-              <a>select them</a>
+              <a id="upload-photo">select them</a>
             {{/file-upload}}
             to upload.
           </p>

--- a/tests/dummy/mirage/config.js
+++ b/tests/dummy/mirage/config.js
@@ -4,14 +4,8 @@ import config from '../config/environment';
 export default function () {
   this.passthrough('/write-coverage');
   this.passthrough(`${config.rootURL}docs/data.json`);
-  this.post('/photos/new', upload(function (db, request) {
-    let { type, name, size, url } = request.requestBody.file;
-    return {
-      filename: name,
-      filesize: size,
-      uploadedAt: new Date(),
-      url,
-      type: type.split('/')[0]
-    };
+  this.post('/photos/new', upload(function (db, request, file) {
+    let { name: filename, size: filesize, url } = file;
+    return db.create('photo', { filename, filesize, url, uploadedAt: new Date() });
   }));
 }

--- a/tests/dummy/mirage/models/photo.js
+++ b/tests/dummy/mirage/models/photo.js
@@ -1,0 +1,4 @@
+import { Model } from 'ember-cli-mirage';
+
+export default Model.extend({
+});

--- a/yarn.lock
+++ b/yarn.lock
@@ -1702,9 +1702,9 @@ broccoli-plugin@^1.0.0, broccoli-plugin@^1.1.0, broccoli-plugin@^1.2.0, broccoli
     rimraf "^2.3.4"
     symlink-or-copy "^1.1.8"
 
-broccoli-sass-source-maps@^2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/broccoli-sass-source-maps/-/broccoli-sass-source-maps-2.0.0.tgz#7f25f9f4b296918cec6e00672c63e75abce33d45"
+broccoli-sass-source-maps@^2.1.0:
+  version "2.1.1"
+  resolved "https://registry.yarnpkg.com/broccoli-sass-source-maps/-/broccoli-sass-source-maps-2.1.1.tgz#5d71d3734234acb102000e5d7776d4c722aad756"
   dependencies:
     broccoli-caching-writer "^3.0.3"
     include-path-searcher "^0.1.0"
@@ -2755,6 +2755,24 @@ ember-cli-babel@^6.0.0-beta.7:
     clone "^2.0.0"
     ember-cli-version-checker "^1.2.0"
 
+ember-cli-babel@^6.6.0:
+  version "6.10.0"
+  resolved "https://registry.yarnpkg.com/ember-cli-babel/-/ember-cli-babel-6.10.0.tgz#81424acd1d97fb13658168121eeb2007d6edee84"
+  dependencies:
+    amd-name-resolver "0.0.7"
+    babel-plugin-debug-macros "^0.1.11"
+    babel-plugin-ember-modules-api-polyfill "^2.0.1"
+    babel-plugin-transform-es2015-modules-amd "^6.24.0"
+    babel-polyfill "^6.16.0"
+    babel-preset-env "^1.5.1"
+    broccoli-babel-transpiler "^6.1.2"
+    broccoli-debug "^0.6.2"
+    broccoli-funnel "^1.0.0"
+    broccoli-source "^1.1.0"
+    clone "^2.0.0"
+    ember-cli-version-checker "^2.1.0"
+    semver "^5.4.1"
+
 ember-cli-broccoli-sane-watcher@^2.0.4:
   version "2.0.4"
   resolved "https://registry.yarnpkg.com/ember-cli-broccoli-sane-watcher/-/ember-cli-broccoli-sane-watcher-2.0.4.tgz#f43f42f75b7509c212fb926cd9aea86ae19264c6"
@@ -2887,23 +2905,23 @@ ember-cli-lodash-subset@^1.0.11, ember-cli-lodash-subset@^1.0.7:
   version "1.0.12"
   resolved "https://registry.yarnpkg.com/ember-cli-lodash-subset/-/ember-cli-lodash-subset-1.0.12.tgz#af2e77eba5dcb0d77f3308d3a6fd7d3450f6e537"
 
-ember-cli-mirage@0.3.4:
-  version "0.3.4"
-  resolved "https://registry.yarnpkg.com/ember-cli-mirage/-/ember-cli-mirage-0.3.4.tgz#eeb9d6e02c0c49c81915762178bab9a42d86ada8"
+ember-cli-mirage@0.4.0:
+  version "0.4.0"
+  resolved "https://registry.yarnpkg.com/ember-cli-mirage/-/ember-cli-mirage-0.4.0.tgz#9156caf74adb1469ed9c208993ee262f6d834efa"
   dependencies:
     broccoli-funnel "^1.0.2"
     broccoli-merge-trees "^1.1.0"
     broccoli-stew "^1.5.0"
     chalk "^1.1.1"
-    ember-cli-babel "^5.1.7"
+    ember-cli-babel "^6.8.2"
     ember-cli-node-assets "^0.1.4"
-    ember-get-config "0.2.1"
+    ember-get-config "^0.2.2"
     ember-inflector "^2.0.0"
     ember-lodash "^4.17.3"
     exists-sync "0.0.3"
     fake-xml-http-request "^1.4.0"
     faker "^3.0.0"
-    pretender "^1.4.2"
+    pretender "^1.5.1"
     route-recognizer "^0.2.3"
 
 ember-cli-node-assets@^0.1.4:
@@ -2984,13 +3002,14 @@ ember-cli-release@1.0.0-beta.2:
     semver "^4.3.1"
     silent-error "^1.0.0"
 
-ember-cli-sass@7.0.0:
-  version "7.0.0"
-  resolved "https://registry.yarnpkg.com/ember-cli-sass/-/ember-cli-sass-7.0.0.tgz#24bdf6e6c13610c57cbddb1f077715588aedcf13"
+ember-cli-sass@7.1.1:
+  version "7.1.1"
+  resolved "https://registry.yarnpkg.com/ember-cli-sass/-/ember-cli-sass-7.1.1.tgz#6ae75b0756e5dbc0db61ec27843929500a38343d"
   dependencies:
     broccoli-funnel "^1.0.0"
     broccoli-merge-trees "^1.1.0"
-    broccoli-sass-source-maps "^2.0.0"
+    broccoli-sass-source-maps "^2.1.0"
+    ember-cli-babel "^5.1.7"
     ember-cli-version-checker "^1.0.2"
 
 ember-cli-shims@^1.1.0:
@@ -3072,6 +3091,13 @@ ember-cli-version-checker@^1.3.1:
 ember-cli-version-checker@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/ember-cli-version-checker/-/ember-cli-version-checker-2.0.0.tgz#e1f7d8e4cdcd752ac35f1611e4daa8836db4c4c7"
+  dependencies:
+    resolve "^1.3.3"
+    semver "^5.3.0"
+
+ember-cli-version-checker@^2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/ember-cli-version-checker/-/ember-cli-version-checker-2.1.0.tgz#fc79a56032f3717cf844ada7cbdec1a06fedb604"
   dependencies:
     resolve "^1.3.3"
     semver "^5.3.0"
@@ -3209,12 +3235,12 @@ ember-fetch@^3.2.6:
     node-fetch "^2.0.0-alpha.3"
     whatwg-fetch "^2.0.3"
 
-ember-get-config@0.2.1:
-  version "0.2.1"
-  resolved "https://registry.yarnpkg.com/ember-get-config/-/ember-get-config-0.2.1.tgz#a1325cceefcb4534c78fc6ccb2be87a3feda6817"
+ember-get-config@^0.2.2:
+  version "0.2.4"
+  resolved "https://registry.yarnpkg.com/ember-get-config/-/ember-get-config-0.2.4.tgz#118492a2a03d73e46004ed777928942021fe1ecd"
   dependencies:
     broccoli-file-creator "^1.1.1"
-    ember-cli-babel "^5.1.6"
+    ember-cli-babel "^6.3.0"
 
 ember-getowner-polyfill@^1.0.0:
   version "1.0.1"
@@ -3252,6 +3278,14 @@ ember-lodash@^4.17.3:
     broccoli-string-replace "^0.1.1"
     ember-cli-babel "^6.4.1"
     lodash-es "^4.17.4"
+
+ember-maybe-import-regenerator-for-testing@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/ember-maybe-import-regenerator-for-testing/-/ember-maybe-import-regenerator-for-testing-1.0.0.tgz#894b8089c5b3067c920b492c81233603852d5c2f"
+  dependencies:
+    broccoli-funnel "^1.0.1"
+    ember-cli-babel "^6.6.0"
+    regenerator-runtime "^0.9.5"
 
 ember-qunit@^2.2.0:
   version "2.2.0"
@@ -3739,6 +3773,10 @@ extsprintf@1.0.2:
 fake-xml-http-request@^1.4.0:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/fake-xml-http-request/-/fake-xml-http-request-1.4.0.tgz#6481c727a0eae9c420bae229dcdfc5369c4b5477"
+
+fake-xml-http-request@^1.6.0:
+  version "1.6.0"
+  resolved "https://registry.yarnpkg.com/fake-xml-http-request/-/fake-xml-http-request-1.6.0.tgz#bd0ac79ae3e2660098282048a12c730a6f64d550"
 
 faker@^3.0.0:
   version "3.1.0"
@@ -6433,12 +6471,12 @@ preserve@^0.2.0:
   version "0.2.0"
   resolved "https://registry.yarnpkg.com/preserve/-/preserve-0.2.0.tgz#815ed1f6ebc65926f865b310c0713bcb3315ce4b"
 
-pretender@^1.4.2:
-  version "1.4.2"
-  resolved "https://registry.yarnpkg.com/pretender/-/pretender-1.4.2.tgz#dde9995dfdf75b28a3dd7a73cde2f9f612e5e8f4"
+pretender@^1.5.1:
+  version "1.6.1"
+  resolved "https://registry.yarnpkg.com/pretender/-/pretender-1.6.1.tgz#77d1e42ac8c6b298f5cd43534a87645df035db8c"
   dependencies:
-    fake-xml-http-request "^1.4.0"
-    route-recognizer "^0.2.3"
+    fake-xml-http-request "^1.6.0"
+    route-recognizer "^0.3.3"
 
 printf@^0.2.3:
   version "0.2.5"
@@ -6764,6 +6802,10 @@ regenerator-runtime@^0.10.0:
   version "0.10.3"
   resolved "https://registry.yarnpkg.com/regenerator-runtime/-/regenerator-runtime-0.10.3.tgz#8c4367a904b51ea62a908ac310bf99ff90a82a3e"
 
+regenerator-runtime@^0.9.5:
+  version "0.9.6"
+  resolved "https://registry.yarnpkg.com/regenerator-runtime/-/regenerator-runtime-0.9.6.tgz#d33eb95d0d2001a4be39659707c51b0cb71ce029"
+
 regenerator-transform@0.9.11:
   version "0.9.11"
   resolved "https://registry.yarnpkg.com/regenerator-transform/-/regenerator-transform-0.9.11.tgz#3a7d067520cb7b7176769eb5ff868691befe1283"
@@ -7034,6 +7076,10 @@ route-recognizer@^0.2.3:
   version "0.2.8"
   resolved "https://registry.yarnpkg.com/route-recognizer/-/route-recognizer-0.2.8.tgz#931e2629b09f351ac8e577aea03ad0151781e625"
 
+route-recognizer@^0.3.3:
+  version "0.3.3"
+  resolved "https://registry.yarnpkg.com/route-recognizer/-/route-recognizer-0.3.3.tgz#1d365e27fa6995e091675f7dc940a8c00353bd29"
+
 rsvp@^3.0.14, rsvp@^3.0.16, rsvp@^3.0.17, rsvp@^3.0.18, rsvp@^3.0.21, rsvp@^3.0.6, rsvp@^3.2.1, rsvp@^3.3.3, rsvp@^3.5.0:
   version "3.5.0"
   resolved "https://registry.yarnpkg.com/rsvp/-/rsvp-3.5.0.tgz#a62c573a4ae4e1dfd0697ebc6242e79c681eaa34"
@@ -7129,6 +7175,10 @@ sax@^1.1.4, sax@~1.2.1:
 semver@^4.2.2, semver@^4.3.1:
   version "4.3.6"
   resolved "https://registry.yarnpkg.com/semver/-/semver-4.3.6.tgz#300bc6e0e86374f7ba61068b5b1ecd57fc6532da"
+
+semver@^5.4.1:
+  version "5.4.1"
+  resolved "https://registry.yarnpkg.com/semver/-/semver-5.4.1.tgz#e059c09d8571f0540823733433505d3a2f00b18e"
 
 send@0.14.1:
   version "0.14.1"


### PR DESCRIPTION
I made some fixes and improvements to the acceptance test helpers. While these are breaking changes (to the test helpers, not the app), they currently didn't work as documented anyway (if at all).

Changes to the mirage `upload` method:
- the callback now receives the original request e.g. so you can get the path arguments and query params
- the "file" is passed as the third argument to the callback instead. It's a `{ name, size, url }` hash as described in the readme (instead of `request.requestBody.file`)
- it fails with a 408 in case of timeout (I think this was the original intent?)

Changes to the `upload` async test helper:
- it's now a named export (previously the readme used both named and default import)
- it accepts a selector for the `<a>` element which the user created. Previously it took a selector for the hidden `<input type="file">` element which is awkward because the user doesn't even create that.
- it uses the ES6 File API directly. I extracted a `dataUrlToBlob` method for convenience when dealing with binary data.
- the helper no longer mutates `file.name`; this failed because it's a read-only property. Instead the user can pass the filename as the second argument to the `File` constructor.