### PR TITLE
Add demo url to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -53,6 +53,7 @@
     "node": "^4.5 || 6.* || >= 7.*"
   },
   "ember-addon": {
-    "configPath": "tests/dummy/config"
+    "configPath": "tests/dummy/config",
+    "demoURL": "https://tim-evans.github.io/ember-file-upload/"
   }
 }


### PR DESCRIPTION
Having a `demoURL` in `ember-addon` will make it available on ember observer right above the github url.