### PR TITLE
Support for files without extension. e.g: "FILE"

### DIFF
--- a/addon/mirage/utils.js
+++ b/addon/mirage/utils.js
@@ -105,7 +105,7 @@ export function extractFileMetadata(file) {
     name: file.name,
     size: file.size,
     type: file.type,
-    extension: file.name.match(/\.(.*)$/)[1]
+    extension: ( file.name.match(/\.(.*)$/) || [] )[1]
   };
 
   let reader = new FileReader();


### PR DESCRIPTION
Previous version was failing on exception as regex match returned null