### PR TITLE
Yield the queue in the file-upload component

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,22 @@ For example, creating an image uploader that uploads images to your API server w
 {{/file-dropzone}}
 ```
 
+It is also possible for you to create a simple file upload button which yields the queue:
+
+```handlebars
+{{#file-upload name="photos"
+               accept="image/*"
+               onfileadd=(action "uploadImage") as |queue|}}
+  <a class="button">
+    {{#if queue.files.length}}
+      Uploading...
+    {{else}}
+      Upload file
+    {{/if}}
+  </a>
+{{/file-upload}}
+```
+
 ## Integration
 
 The addon emits an event when a file is queued for upload. You may trigger the upload by calling the `upload` function on the file, which returns a promise that is resolved when the file has finished uploading and is rejected if the file couldn't be uploaded.
@@ -93,7 +109,7 @@ export default Ember.Route.extend({
       filename: get(file, 'name'),
       filesize: get(file, 'size')
     });
-    
+
     try {
       file.readAsDataURL().then(function (url) {
         if (get(photo, 'url') == null) {

--- a/addon/components/file-upload/template.hbs
+++ b/addon/components/file-upload/template.hbs
@@ -1,2 +1,2 @@
 <input id={{for}} type="file" accept={{accept}} multiple={{multiple}} disabled={{disabled}} onchange={{action "change" value="target.files"}} style="display: none;">
-{{yield}}
+{{yield queue}}

--- a/addon/services/file-queue.js
+++ b/addon/services/file-queue.js
@@ -28,6 +28,8 @@ export default Service.extend({
     accessed by name via the `find` method.
    */
   init() {
+    this._super(...arguments);
+    
     set(this, 'queues', A());
     set(this, 'files', A());
   },


### PR DESCRIPTION
Issue: #117 

I believe it's useful to yield the queue in the file-upload component (similarly to file-dropzone). This allows a simplification in some simple manipulations inside the file-upload component. See the issue for an example

I also took the freedom to add a missing `this._super(...arguments)` in the file-queue service's init method