### PR TITLE
Copy item details out of DataTransfer object when scheduling a dragenter handler, so they can be reliably accessed

### DIFF
--- a/addon/components/file-dropzone/component.js
+++ b/addon/components/file-dropzone/component.js
@@ -130,7 +130,8 @@ export default Component.extend({
     let dataTransfer = DataTransfer.create({
       queue: get(this, 'queue'),
       source: evt.source,
-      dataTransfer: evt.dataTransfer
+      dataTransfer: evt.dataTransfer,
+      itemDetails: evt.itemDetails
     });
     this[DATA_TRANSFER] = dataTransfer;
 

--- a/addon/system/data-transfer.js
+++ b/addon/system/data-transfer.js
@@ -7,6 +7,7 @@ const getDataSupport = {};
 export default EmberObject.extend({
 
   dataTransfer: null,
+  itemDetails: null,
 
   queue: null,
 
@@ -25,7 +26,7 @@ export default EmberObject.extend({
     }
   },
 
-  valid: computed('dataTransfer.files', 'files', {
+  valid: computed('dataTransfer.files', 'files', 'itemDetails', {
     get() {
       if (get(this, 'files') == null) {
         return true;
@@ -33,20 +34,28 @@ export default EmberObject.extend({
 
       return (
         get(this, 'dataTransfer.items.length') ||
-        get(this, 'dataTransfer.files.length')
+        get(this, 'dataTransfer.files.length') ||
+        get(this, 'itemDetails.length')
       ) === get(this, 'files.length');
     }
   }),
 
-  files: computed('queue.{accept,multiple}', 'dataTransfer', {
+  files: computed('queue.{accept,multiple}', 'dataTransfer', 'itemDetails', {
     get() {
       let fileList = get(this, 'dataTransfer.files');
       let itemList = get(this, 'dataTransfer.items');
+      let itemDetails = get(this, 'itemDetails');
 
       if ((fileList == null && itemList) ||
           (itemList != null && fileList != null &&
            itemList.length > fileList.length)) {
         fileList = itemList;
+      }
+
+      if ((fileList == null && itemDetails) ||
+          (itemDetails != null && fileList != null &&
+           itemDetails.length > fileList.length)) {
+        fileList = itemDetails;
       }
 
       if (fileList == null) {

--- a/addon/system/drag-listener.js
+++ b/addon/system/drag-listener.js
@@ -102,6 +102,18 @@ export default class {
     return areSomeTypesFiles ? 'os' : 'web';
   }
 
+  getDataTransferItemDetails(evt) {
+    let itemDetails = [];
+    for(let i = 0; i < evt.dataTransfer.items.length; i++) {
+      let item = evt.dataTransfer.items[i];
+      itemDetails.push({
+        kind: item.kind,
+        type: item.type
+      })
+    }
+    return itemDetails;
+  }
+
   dragenter(evt) {
     let listener = this.findListener(evt);
     let lastListener = this._stack[this._stack.length - 1];
@@ -114,7 +126,8 @@ export default class {
     if (listener) {
       this.scheduleEvent('dragenter', listener, {
         source: this.getEventSource(evt),
-        dataTransfer: evt.dataTransfer
+        dataTransfer: evt.dataTransfer,
+        itemDetails: this.getDataTransferItemDetails(evt)
       });
     }
     this._listener = listener;
@@ -139,7 +152,8 @@ export default class {
       }
       this.scheduleEvent('dragenter', listener, {
         source: this.getEventSource(evt),
-        dataTransfer: evt.dataTransfer
+        dataTransfer: evt.dataTransfer,
+        itemDetails: this.getDataTransferItemDetails(evt)
       });
       if (this._stack.indexOf(listener) !== -1) {
         listener.handlers.dragover(evt);


### PR DESCRIPTION
This is necessary because in Chrome, by design, the contents of evt.dataTransfer.items are only available during the event frame that the drag event is being handled. [bug-tracker-link]

Fixes #104

[bug-tracker-link]: https://bugs.chromium.org/p/chromium/issues/detail?id=137231#c1
