### PR TITLE
Don't depend on jQuery

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -15,6 +15,7 @@ module.exports = {
     browser: true
   },
   rules: {
+    'ember/no-jquery': 2
   },
   overrides: [
     // node files

--- a/addon/components/file-dropzone/component.js
+++ b/addon/components/file-dropzone/component.js
@@ -7,6 +7,7 @@ import { computed, set, get } from '@ember/object';
 import layout from './template';
 import DataTransfer from '../../system/data-transfer';
 import uuid from '../../system/uuid';
+import parseHTML from '../../system/parse-html';
 import DragListener from '../../system/drag-listener';
 
 const DATA_TRANSFER = 'DATA_TRANSFER' + uuid.short();
@@ -182,7 +183,7 @@ export default Component.extend({
 
     let html = this[DATA_TRANSFER].getData('text/html');
     if (html) {
-      let parsedHtml = new DOMParser().parseFromString(html, 'text/html');
+      let parsedHtml = parseHTML(html);
       let img = parsedHtml.getElementsByTagName('img')[0];
       if (img) {
         url = img.src;

--- a/addon/components/file-dropzone/component.js
+++ b/addon/components/file-dropzone/component.js
@@ -3,7 +3,6 @@ import Component from '@ember/component';
 
 import { inject as service } from '@ember/service';
 import { bind } from '@ember/runloop';
-import $ from 'jquery';
 import { computed, set, get } from '@ember/object';
 import layout from './template';
 import DataTransfer from '../../system/data-transfer';
@@ -183,8 +182,9 @@ export default Component.extend({
 
     let html = this[DATA_TRANSFER].getData('text/html');
     if (html) {
-      let img = $(html)[1];
-      if (img.tagName === 'IMG') {
+      let parsedHtml = new DOMParser().parseFromString(html, 'text/html');
+      let img = parsedHtml.getElementsByTagName('img')[0];
+      if (img) {
         url = img.src;
       }
     }

--- a/addon/components/file-upload/component.js
+++ b/addon/components/file-upload/component.js
@@ -1,6 +1,7 @@
 import { assert } from '@ember/debug';
 import Component from '@ember/component';
 import { inject as service } from '@ember/service';
+import { DEBUG } from '@glimmer/env';
 import {
   getProperties,
   setProperties,
@@ -9,13 +10,6 @@ import {
 } from '@ember/object';
 import layout from './template';
 import uuid from '../../system/uuid';
-
-const VALID_TAGS = ['a', 'abbr', 'area', 'audio', 'b', 'bdo', 'br', 'canvas', 'cite',
-                    'code', 'command', 'datalist', 'del', 'dfn', 'em', 'embed', 'i',
-                    'iframe', 'img', 'kbd', 'mark', 'math', 'noscript', 'object', 'q',
-                    'ruby', 'samp', 'script', 'small', 'span', 'strong', 'sub', 'sup',
-                    'svg', 'time', 'var', 'video', 'wbr',
-                    'path', 'g', 'use', 'circle'];
 
 /**
   `{{file-upload}}` is an element that will open a dialog for
@@ -84,7 +78,7 @@ const VALID_TAGS = ['a', 'abbr', 'area', 'audio', 'b', 'bdo', 'br', 'canvas', 'c
   @class file-upload
   @type Ember.Component
  */
-export default Component.extend({
+const component = Component.extend({
   tagName: 'label',
   classNames: ['file-upload'],
 
@@ -161,17 +155,6 @@ export default Component.extend({
     }
   }),
 
-  didInsertElement() {
-    let id = get(this, 'for');
-    assert(`Changing the tagName of {{file-upload}} to "${get(this, 'tagName')}" will break interactions.`, get(this, 'tagName') === 'label');
-    this.element.querySelector('*').each(function (_, element) {
-      if (element.id !== id &&
-          VALID_TAGS.indexOf(element.tagName.toLowerCase()) === -1) {
-        assert(`"${element.outerHTML}" is not allowed as a child of {{file-upload}}.`);
-      }
-    });
-  },
-
   actions: {
     change(files) {
       get(this, 'queue')._addFiles(files, 'browse');
@@ -179,3 +162,27 @@ export default Component.extend({
     }
   }
 });
+
+if (DEBUG) {
+  const VALID_TAGS = ['a', 'abbr', 'area', 'audio', 'b', 'bdo', 'br', 'canvas', 'cite',
+                      'code', 'command', 'datalist', 'del', 'dfn', 'em', 'embed', 'i',
+                      'iframe', 'img', 'kbd', 'mark', 'math', 'noscript', 'object', 'q',
+                      'ruby', 'samp', 'script', 'small', 'span', 'strong', 'sub', 'sup',
+                      'svg', 'time', 'var', 'video', 'wbr',
+                      'path', 'g', 'use', 'circle'];
+
+  component.reopen({
+    didInsertElement() {
+      let id = get(this, 'for');
+      assert(`Changing the tagName of {{file-upload}} to "${get(this, 'tagName')}" will break interactions.`, get(this, 'tagName') === 'label');
+      this.element.querySelectorAll('*').forEach(function (element) {
+        if (element.id !== id &&
+            VALID_TAGS.indexOf(element.tagName.toLowerCase()) === -1) {
+          assert(`"${element.outerHTML}" is not allowed as a child of {{file-upload}}.`);
+        }
+      });
+    }
+  });
+}
+
+export default component;

--- a/addon/components/file-upload/component.js
+++ b/addon/components/file-upload/component.js
@@ -164,7 +164,7 @@ export default Component.extend({
   didInsertElement() {
     let id = get(this, 'for');
     assert(`Changing the tagName of {{file-upload}} to "${get(this, 'tagName')}" will break interactions.`, get(this, 'tagName') === 'label');
-    this.$('*').each(function (_, element) {
+    this.element.querySelector('*').each(function (_, element) {
       if (element.id !== id &&
           VALID_TAGS.indexOf(element.tagName.toLowerCase()) === -1) {
         assert(`"${element.outerHTML}" is not allowed as a child of {{file-upload}}.`);
@@ -175,7 +175,7 @@ export default Component.extend({
   actions: {
     change(files) {
       get(this, 'queue')._addFiles(files, 'browse');
-      this.$().children('input').val(null);
+      this.element.querySelector('input').value = null;
     }
   }
 });

--- a/addon/system/http-request.js
+++ b/addon/system/http-request.js
@@ -1,6 +1,9 @@
 import { bind } from '@ember/runloop';
 import RSVP from 'rsvp';
 import trim from './trim';
+import parseHTML from './parse-html';
+import parseXML from './parse-xml';
+import parseJSON from './parse-json';
 
 function getHeader(headers, header) {
   let headerKeys = Object.keys(headers);
@@ -28,19 +31,15 @@ function parseResponse(request) {
   let contentType = (getHeader(headers, 'Content-Type') || '').split(';');
 
   // Parse body according to the Content-Type received by the server
-  try {
-    if (contentType.indexOf('text/html') !== -1) {
-      body = new DOMParser().parseFromString(body, 'text/html');
-    } else if (contentType.indexOf('text/xml') !== -1) {
-      body = new DOMParser().parseFromString(body, 'text/xml');
-    } else if (contentType.indexOf('application/json') !== -1 ||
-              contentType.indexOf('application/vnd.api+json') !== -1 ||
-              contentType.indexOf('text/javascript') !== -1 ||
-              contentType.indexOf('application/javascript') !== -1) {
-      body = JSON.parse(body);
-    }
-  } catch(e) {
-    body = undefined;
+  if (contentType.indexOf('text/html') !== -1) {
+    body = parseHTML(body);
+  } else if (contentType.indexOf('text/xml') !== -1) {
+    body = parseXML(body);
+  } else if (contentType.indexOf('application/json') !== -1 ||
+            contentType.indexOf('application/vnd.api+json') !== -1 ||
+            contentType.indexOf('text/javascript') !== -1 ||
+            contentType.indexOf('application/javascript') !== -1) {
+    body = parseJSON(body);
   }
 
   return {

--- a/addon/system/http-request.js
+++ b/addon/system/http-request.js
@@ -1,6 +1,5 @@
 import { bind } from '@ember/runloop';
 import RSVP from 'rsvp';
-import $ from 'jquery';
 import trim from './trim';
 
 function getHeader(headers, header) {
@@ -29,15 +28,19 @@ function parseResponse(request) {
   let contentType = (getHeader(headers, 'Content-Type') || '').split(';');
 
   // Parse body according to the Content-Type received by the server
-  if (contentType.indexOf('text/html') !== -1) {
-    body = $.parseHTML(body);
-  } else if (contentType.indexOf('text/xml') !== -1) {
-    body = $.parseXML(body);
-  } else if (contentType.indexOf('application/json') !== -1 ||
-             contentType.indexOf('application/vnd.api+json') !== -1 ||
-             contentType.indexOf('text/javascript') !== -1 ||
-             contentType.indexOf('application/javascript') !== -1) {
-    body = $.parseJSON(body);
+  try {
+    if (contentType.indexOf('text/html') !== -1) {
+      body = new DOMParser().parseFromString(body, 'text/html');
+    } else if (contentType.indexOf('text/xml') !== -1) {
+      body = new DOMParser().parseFromString(body, 'text/xml');
+    } else if (contentType.indexOf('application/json') !== -1 ||
+              contentType.indexOf('application/vnd.api+json') !== -1 ||
+              contentType.indexOf('text/javascript') !== -1 ||
+              contentType.indexOf('application/javascript') !== -1) {
+      body = JSON.parse(body);
+    }
+  } catch(e) {
+    body = undefined;
   }
 
   return {

--- a/addon/system/parse-html.js
+++ b/addon/system/parse-html.js
@@ -1,0 +1,5 @@
+export default function parseHTML(string) {
+  let tmp = document.implementation.createHTMLDocument();
+  tmp.body.innerHTML = string;
+  return [tmp.body];
+}

--- a/addon/system/parse-json.js
+++ b/addon/system/parse-json.js
@@ -1,0 +1,11 @@
+import { assert } from '@ember/debug';
+
+export default function parseJSON(string) {
+  let json = null;
+  try {
+    json = JSON.parse(string);
+  } catch(e) {
+    assert(`Invalid JSON: ${string}`);
+  }
+  return json;
+}

--- a/addon/system/parse-xml.js
+++ b/addon/system/parse-xml.js
@@ -1,0 +1,27 @@
+import { assert } from '@ember/debug';
+import { DEBUG } from '@glimmer/env';
+
+// This method is taken from
+// https://github.com/jquery/jquery/blob/2d4f53416e5f74fa98e0c1d66b6f3c285a12f0ce/src/ajax/parseXML.js
+
+export default function parseXML(data) {
+    let xml;
+    if (!data || typeof data !== "string" ) {
+      return null;
+    }
+
+    // Support: IE 9 - 11 only
+    // IE throws on parseFromString with invalid input.
+    try {
+      xml = (new window.DOMParser()).parseFromString( data, "text/xml" );
+    } catch ( e ) {
+      xml = undefined;
+    }
+
+    if (DEBUG) {
+      if (!xml || xml.getElementsByTagName( "parsererror" ).length) {
+        assert(`Invalid XML: ${data}`);
+      }
+    }
+    return xml;
+}

--- a/addon/system/parse-xml.js
+++ b/addon/system/parse-xml.js
@@ -6,20 +6,20 @@ import { DEBUG } from '@glimmer/env';
 
 export default function parseXML(data) {
     let xml;
-    if (!data || typeof data !== "string" ) {
+    if (!data || typeof data !== 'string') {
       return null;
     }
 
     // Support: IE 9 - 11 only
     // IE throws on parseFromString with invalid input.
     try {
-      xml = (new window.DOMParser()).parseFromString( data, "text/xml" );
-    } catch ( e ) {
+      xml = (new window.DOMParser()).parseFromString(data, 'text/xml');
+    } catch(e) {
       xml = undefined;
     }
 
     if (DEBUG) {
-      if (!xml || xml.getElementsByTagName( "parsererror" ).length) {
+      if (!xml || xml.getElementsByTagName('parsererror').length) {
         assert(`Invalid XML: ${data}`);
       }
     }

--- a/ember-cli-build.js
+++ b/ember-cli-build.js
@@ -15,6 +15,9 @@ module.exports = function(defaults) {
     svgJar: {
       strategy: 'inline',
       sourceDirs: ['tests/dummy/public/assets/images']
+    },
+    vendorFiles: {
+      'jquery.js': null
     }
   });
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "ember-file-upload",
-  "version": "2.2.4",
+  "version": "2.3.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -11,7 +11,7 @@
       "dev": true,
       "requires": {
         "broccoli-funnel": "2.0.1",
-        "ember-cli-babel": "6.10.0"
+        "ember-cli-babel": "6.12.0"
       },
       "dependencies": {
         "broccoli-funnel": {
@@ -643,13 +643,13 @@
         "babel-helper-function-name": "6.24.1",
         "babel-runtime": "6.26.0",
         "babel-types": "6.26.0",
-        "lodash": "4.17.4"
+        "lodash": "4.17.5"
       },
       "dependencies": {
         "lodash": {
-          "version": "4.17.4",
-          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz",
-          "integrity": "sha1-eCA6TRwyiuHYbcpkYONptX9AVa4="
+          "version": "4.17.5",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.5.tgz",
+          "integrity": "sha512-svL3uiZf1RwhH+cWrfZn3A4+U58wbP0tGVTLQPbjplZxZ8ROD9VLuNgsRniTlLe7OlSqR79RUehXgpBW/s0IQw=="
         }
       }
     },
@@ -709,13 +709,13 @@
       "requires": {
         "babel-runtime": "6.26.0",
         "babel-types": "6.26.0",
-        "lodash": "4.17.4"
+        "lodash": "4.17.5"
       },
       "dependencies": {
         "lodash": {
-          "version": "4.17.4",
-          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz",
-          "integrity": "sha1-eCA6TRwyiuHYbcpkYONptX9AVa4="
+          "version": "4.17.5",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.5.tgz",
+          "integrity": "sha512-svL3uiZf1RwhH+cWrfZn3A4+U58wbP0tGVTLQPbjplZxZ8ROD9VLuNgsRniTlLe7OlSqR79RUehXgpBW/s0IQw=="
         }
       }
     },
@@ -790,9 +790,9 @@
       }
     },
     "babel-plugin-ember-modules-api-polyfill": {
-      "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/babel-plugin-ember-modules-api-polyfill/-/babel-plugin-ember-modules-api-polyfill-2.2.1.tgz",
-      "integrity": "sha1-5j+QzDxxzGs7aftRtPYDEtbPc0w=",
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-ember-modules-api-polyfill/-/babel-plugin-ember-modules-api-polyfill-2.3.0.tgz",
+      "integrity": "sha512-cv5ZimF5X52uW7Ul83UUxtsFZE6rZYkMv6qWnAeiDLT1/KtpVrTkJpwzDlvJ/FhKJZ43ih4GbFbhuhBKKT7vIw==",
       "requires": {
         "ember-rfc176-data": "0.3.1"
       }
@@ -922,13 +922,13 @@
         "babel-template": "6.26.0",
         "babel-traverse": "6.26.0",
         "babel-types": "6.26.0",
-        "lodash": "4.17.4"
+        "lodash": "4.17.5"
       },
       "dependencies": {
         "lodash": {
-          "version": "4.17.4",
-          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz",
-          "integrity": "sha1-eCA6TRwyiuHYbcpkYONptX9AVa4="
+          "version": "4.17.5",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.5.tgz",
+          "integrity": "sha512-svL3uiZf1RwhH+cWrfZn3A4+U58wbP0tGVTLQPbjplZxZ8ROD9VLuNgsRniTlLe7OlSqR79RUehXgpBW/s0IQw=="
         }
       }
     },
@@ -1164,14 +1164,14 @@
       "integrity": "sha1-N5k3q8Z9eJWXCtxiHyhM2WbPIVM=",
       "requires": {
         "babel-runtime": "6.26.0",
-        "core-js": "2.5.1",
+        "core-js": "2.5.4",
         "regenerator-runtime": "0.10.5"
       },
       "dependencies": {
         "core-js": {
-          "version": "2.5.1",
-          "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.5.1.tgz",
-          "integrity": "sha1-rmh03GaTd4m4B1T/VCjfZoGcpQs="
+          "version": "2.5.4",
+          "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.5.4.tgz",
+          "integrity": "sha1-8si/GB8qgLkvNgEhQpzmOi8K6uA="
         },
         "regenerator-runtime": {
           "version": "0.10.5",
@@ -1212,7 +1212,7 @@
         "babel-plugin-transform-es2015-unicode-regex": "6.24.1",
         "babel-plugin-transform-exponentiation-operator": "6.24.1",
         "babel-plugin-transform-regenerator": "6.26.0",
-        "browserslist": "2.9.1",
+        "browserslist": "2.11.3",
         "invariant": "2.2.2",
         "semver": "5.4.1"
       }
@@ -2335,12 +2335,12 @@
       }
     },
     "browserslist": {
-      "version": "2.9.1",
-      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-2.9.1.tgz",
-      "integrity": "sha512-3n3nPdbUqn3nWmsy4PeSQthz2ja1ndpoXta+dwFFNhveGjMg6FXpWYe12vsTpNoXJbzx3j7GZXdtoVIdvh3JbA==",
+      "version": "2.11.3",
+      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-2.11.3.tgz",
+      "integrity": "sha512-yWu5cXT7Av6mVwzWc8lMsJMHWn4xyjSuGYi4IozbVTLUOEYPSagUB8kiMDUHA1fS3zjr8nkxkn9jdvug4BBRmA==",
       "requires": {
-        "caniuse-lite": "1.0.30000777",
-        "electron-to-chromium": "1.3.27"
+        "caniuse-lite": "1.0.30000821",
+        "electron-to-chromium": "1.3.41"
       }
     },
     "bser": {
@@ -2448,9 +2448,9 @@
       }
     },
     "caniuse-lite": {
-      "version": "1.0.30000777",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30000777.tgz",
-      "integrity": "sha1-McGKSozUl4LrswXI6Kk+azs+TxM="
+      "version": "1.0.30000821",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30000821.tgz",
+      "integrity": "sha512-qyYay02wr/5k7PO86W+LKFaEUZfWIvT65PaXuPP16jkSpgZGIsSstHKiYAPVLjTj98j2WnWwZg8CjXPx7UIPYg=="
     },
     "capture-exit": {
       "version": "1.2.0",
@@ -3414,9 +3414,9 @@
       "dev": true
     },
     "electron-to-chromium": {
-      "version": "1.3.27",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.27.tgz",
-      "integrity": "sha1-eOy4o5kGYYe7N07t412ccFZagD0="
+      "version": "1.3.41",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.41.tgz",
+      "integrity": "sha1-fjNkPgDNhe39F+BBlPbQDnNzcjU="
     },
     "ember-cli": {
       "version": "3.0.0",
@@ -3938,17 +3938,17 @@
       }
     },
     "ember-cli-babel": {
-      "version": "6.10.0",
-      "resolved": "https://registry.npmjs.org/ember-cli-babel/-/ember-cli-babel-6.10.0.tgz",
-      "integrity": "sha512-MbgXmePweFzjkpN0l2eYFIU6XKfEKCaAx4Xk9wdL3vsPAvAm4N0DXnz4pOQ3OLezhl0bJJvutD3uLQ7Eo3sSTA==",
+      "version": "6.12.0",
+      "resolved": "https://registry.npmjs.org/ember-cli-babel/-/ember-cli-babel-6.12.0.tgz",
+      "integrity": "sha512-LMwZ3Xf3Q3jQUXaJtLLJsbbhRZRNv/iea64lZ8OgqZp1fh66CSXfmqV3L9QSuYQKPDNqFiu2v6IpOT08C6GU6w==",
       "requires": {
         "amd-name-resolver": "0.0.7",
         "babel-plugin-debug-macros": "0.1.11",
-        "babel-plugin-ember-modules-api-polyfill": "2.2.1",
+        "babel-plugin-ember-modules-api-polyfill": "2.3.0",
         "babel-plugin-transform-es2015-modules-amd": "6.24.1",
         "babel-polyfill": "6.26.0",
         "babel-preset-env": "1.6.1",
-        "broccoli-babel-transpiler": "6.1.2",
+        "broccoli-babel-transpiler": "6.1.4",
         "broccoli-debug": "0.6.4",
         "broccoli-funnel": "1.2.0",
         "broccoli-source": "1.1.0",
@@ -3975,7 +3975,7 @@
             "convert-source-map": "1.5.1",
             "debug": "2.6.9",
             "json5": "0.5.1",
-            "lodash": "4.17.4",
+            "lodash": "4.17.5",
             "minimatch": "3.0.4",
             "path-is-absolute": "1.0.1",
             "private": "0.1.8",
@@ -3989,9 +3989,9 @@
           "integrity": "sha512-q/UEjfGJ2Cm3oKV71DJz9d25TPnq5rhBVL2Q4fA5wcC3jcrdn7+SssEybFIxwAvvP+YCsCYNKughoF33GxgycQ=="
         },
         "broccoli-babel-transpiler": {
-          "version": "6.1.2",
-          "resolved": "https://registry.npmjs.org/broccoli-babel-transpiler/-/broccoli-babel-transpiler-6.1.2.tgz",
-          "integrity": "sha512-o1OUe5RZ5EP5+QICEmRNvWlhMvIciMisVACHu6qUPt6dE0Q0UnI5lUpWTmuXg/X+QuznqD/s1PApIpahv/QMZw==",
+          "version": "6.1.4",
+          "resolved": "https://registry.npmjs.org/broccoli-babel-transpiler/-/broccoli-babel-transpiler-6.1.4.tgz",
+          "integrity": "sha512-h63g7iOBWdxj0GuZw8kNsyaD1T9weKsY3I+gp3rOefozbHwUesJ43vzLy0jj3t/rbiP2czcJAlyHS48EcRil8Q==",
           "requires": {
             "babel-core": "6.26.0",
             "broccoli-funnel": "1.2.0",
@@ -4035,9 +4035,9 @@
           "integrity": "sha1-Hq3nrMASA0rYTiOWdn6tn6VJWCE="
         },
         "lodash": {
-          "version": "4.17.4",
-          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz",
-          "integrity": "sha1-eCA6TRwyiuHYbcpkYONptX9AVa4="
+          "version": "4.17.5",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.5.tgz",
+          "integrity": "sha512-svL3uiZf1RwhH+cWrfZn3A4+U58wbP0tGVTLQPbjplZxZ8ROD9VLuNgsRniTlLe7OlSqR79RUehXgpBW/s0IQw=="
         },
         "rsvp": {
           "version": "3.6.2",
@@ -4088,7 +4088,7 @@
         "broccoli-filter": "1.2.4",
         "broccoli-funnel": "1.2.0",
         "broccoli-merge-trees": "1.2.4",
-        "ember-cli-babel": "6.10.0",
+        "ember-cli-babel": "6.12.0",
         "escodegen": "1.9.0",
         "esprima": "3.1.3",
         "exists-sync": "0.0.3",
@@ -4363,7 +4363,7 @@
         "broccoli-merge-trees": "1.2.4",
         "broccoli-stew": "1.5.0",
         "chalk": "1.1.3",
-        "ember-cli-babel": "6.10.0",
+        "ember-cli-babel": "6.12.0",
         "ember-cli-node-assets": "0.1.6",
         "ember-get-config": "0.2.4",
         "ember-inflector": "2.1.0",
@@ -4498,7 +4498,7 @@
       "integrity": "sha1-MHoVfp82oNMmIa4kfv+4kf+VH8c=",
       "dev": true,
       "requires": {
-        "ember-cli-babel": "6.10.0",
+        "ember-cli-babel": "6.12.0",
         "ember-qunit": "3.1.0"
       }
     },
@@ -4612,7 +4612,7 @@
       "integrity": "sha512-mlSXX9SciIRwGkFTX6XGyJYp4ry6oCFZRxh5jJ7VH8UXLTNx2ZACtDTwaWtNhYrWXgKyiDUvmD8enD56aePWRA==",
       "dev": true,
       "requires": {
-        "ember-cli-babel": "6.10.0"
+        "ember-cli-babel": "6.12.0"
       }
     },
     "ember-cli-uglify": {
@@ -4671,7 +4671,7 @@
       "dev": true,
       "requires": {
         "broccoli-file-creator": "1.1.1",
-        "ember-cli-babel": "6.10.0"
+        "ember-cli-babel": "6.12.0"
       }
     },
     "ember-getowner-polyfill": {
@@ -4706,7 +4706,7 @@
       "integrity": "sha512-o7X+MdPuMgH6GGP8JsZ6mr+WYiCcymzjPLr0ct2IUw4lh1EwVtmePuY6fBLuWmyQE1nJq4smDyNoOCE74n3f7g==",
       "dev": true,
       "requires": {
-        "ember-cli-babel": "6.10.0"
+        "ember-cli-babel": "6.12.0"
       }
     },
     "ember-load-initializers": {
@@ -4715,7 +4715,7 @@
       "integrity": "sha1-SRnq8G9t/sp+E0Yz2MBabJkh5uc=",
       "dev": true,
       "requires": {
-        "ember-cli-babel": "6.10.0"
+        "ember-cli-babel": "6.12.0"
       }
     },
     "ember-lodash": {
@@ -4728,7 +4728,7 @@
         "broccoli-funnel": "1.2.0",
         "broccoli-merge-trees": "2.0.0",
         "broccoli-string-replace": "0.1.2",
-        "ember-cli-babel": "6.10.0",
+        "ember-cli-babel": "6.12.0",
         "lodash-es": "4.17.4"
       }
     },
@@ -4740,7 +4740,7 @@
       "requires": {
         "broccoli-funnel": "1.2.0",
         "broccoli-merge-trees": "1.2.4",
-        "ember-cli-babel": "6.10.0",
+        "ember-cli-babel": "6.12.0",
         "regenerator-runtime": "0.9.6"
       },
       "dependencies": {
@@ -4778,7 +4778,7 @@
         "broccoli-funnel": "2.0.1",
         "broccoli-merge-trees": "2.0.0",
         "common-tags": "1.5.1",
-        "ember-cli-babel": "6.10.0",
+        "ember-cli-babel": "6.12.0",
         "ember-cli-test-loader": "2.2.0",
         "qunit": "2.4.1"
       },
@@ -4816,7 +4816,7 @@
         "babel-plugin-debug-macros": "0.1.11",
         "broccoli-funnel": "1.2.0",
         "broccoli-merge-trees": "2.0.0",
-        "ember-cli-babel": "6.10.0",
+        "ember-cli-babel": "6.12.0",
         "ember-cli-version-checker": "2.1.0",
         "resolve": "1.5.0"
       },
@@ -4916,7 +4916,7 @@
         "broccoli-funnel": {
           "version": "2.0.1",
           "resolved": "https://registry.npmjs.org/broccoli-funnel/-/broccoli-funnel-2.0.1.tgz",
-          "integrity": "sha512-C8Lnp9TVsSSiZMGEF16C0dCiNg2oJqUKwuZ1K4kVC6qRPG/2Cj/rtB5kRCC9qEbwqhX71bDbfHROx0L3J7zXQg==",
+          "integrity": "sha1-aCPHO2de94//p6uADwg+dotR1Ek=",
           "dev": true,
           "requires": {
             "array-equal": "1.0.0",
@@ -4937,7 +4937,7 @@
         "ember-cli-version-checker": {
           "version": "2.1.0",
           "resolved": "https://registry.npmjs.org/ember-cli-version-checker/-/ember-cli-version-checker-2.1.0.tgz",
-          "integrity": "sha512-ssiNyVTp+PphroFum8guHX9py4xU1PCxkRYgb25NxumgjpKTPjhkgTfpRRKXlIQe+/wVMmhf+Uv6w9vSLZKWKQ==",
+          "integrity": "sha1-/HmlYDLzcXz4RK2ny97BoG/ttgQ=",
           "dev": true,
           "requires": {
             "resolve": "1.5.0",
@@ -4968,7 +4968,7 @@
         "broccoli-svg-optimizer": "1.0.2",
         "broccoli-symbolizer": "0.5.0",
         "cheerio": "0.20.0",
-        "ember-cli-babel": "6.10.0",
+        "ember-cli-babel": "6.12.0",
         "lodash": "4.17.5",
         "mkdirp": "0.5.1",
         "path-posix": "1.0.0"
@@ -8384,7 +8384,7 @@
     "jquery": {
       "version": "3.3.1",
       "resolved": "https://registry.npmjs.org/jquery/-/jquery-3.3.1.tgz",
-      "integrity": "sha512-Ubldcmxp5np52/ENotGxlLe6aGMvmF4R8S6tZjsP6Knsaxd/xp3Zrh50cG93lR6nPXyUFwzN3ZSOQI0wRJNdGg==",
+      "integrity": "sha1-lYzinoHJeQ8xvneS311NlfxX+8o=",
       "dev": true
     },
     "js-base64": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -4768,6 +4768,28 @@
         }
       }
     },
+    "ember-native-dom-event-dispatcher": {
+      "version": "0.6.4",
+      "resolved": "https://registry.npmjs.org/ember-native-dom-event-dispatcher/-/ember-native-dom-event-dispatcher-0.6.4.tgz",
+      "integrity": "sha512-b4BbEzxSzeIqcS9b1IA3Y8k6hWl0u0yZP3Ade1nNlQLpU213ifbece3iOi9VNdTFeX2I8sPIDHDivmJm7NoBZA==",
+      "dev": true,
+      "requires": {
+        "ember-cli-babel": "6.12.0",
+        "ember-cli-version-checker": "2.1.0"
+      },
+      "dependencies": {
+        "ember-cli-version-checker": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/ember-cli-version-checker/-/ember-cli-version-checker-2.1.0.tgz",
+          "integrity": "sha512-ssiNyVTp+PphroFum8guHX9py4xU1PCxkRYgb25NxumgjpKTPjhkgTfpRRKXlIQe+/wVMmhf+Uv6w9vSLZKWKQ==",
+          "dev": true,
+          "requires": {
+            "resolve": "1.5.0",
+            "semver": "5.4.1"
+          }
+        }
+      }
+    },
     "ember-qunit": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/ember-qunit/-/ember-qunit-3.1.0.tgz",

--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
     "ember-cli-uglify": "^2.0.0",
     "ember-load-initializers": "^1.0.0",
     "ember-maybe-import-regenerator": "^0.1.6",
+    "ember-native-dom-event-dispatcher": "^0.6.4",
     "ember-resolver": "^4.0.0",
     "ember-route-action-helper": "2.0.0",
     "ember-source": "~3.0.0",

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "test": "ember try:each"
   },
   "dependencies": {
-    "ember-cli-babel": "^6.6.0",
+    "ember-cli-babel": "^6.12.0",
     "ember-cli-htmlbars": "^2.0.1"
   },
   "devDependencies": {

--- a/tests/unit/system/http-request-test.js
+++ b/tests/unit/system/http-request-test.js
@@ -85,7 +85,7 @@ module('http-request', function(hooks) {
       assert.deepEqual(response.headers, {
         'Content-Type': 'text/html'
       });
-      assert.equal(response.body.body.textContent, 'ok');
+      assert.equal(response.body[0].textContent, 'ok');
     });
 
     assert.deepEqual(this.request.requestBody, {

--- a/tests/unit/system/http-request-test.js
+++ b/tests/unit/system/http-request-test.js
@@ -85,7 +85,7 @@ module('http-request', function(hooks) {
       assert.deepEqual(response.headers, {
         'Content-Type': 'text/html'
       });
-      assert.equal(response.body[0].textContent, 'ok');
+      assert.equal(response.body.body.textContent, 'ok');
     });
 
     assert.deepEqual(this.request.requestBody, {


### PR DESCRIPTION
By removing jQuery usage, enables to use this addon in Ember applications where jquery.js is set to null in ember-cli-build.js.