### PR TITLE
ember-native-dom-event-dispatcher should be in ember-try config instead

### DIFF
--- a/config/ember-try.js
+++ b/config/ember-try.js
@@ -14,7 +14,8 @@ module.exports = function() {
           name: 'ember-lts-2.16',
           npm: {
             devDependencies: {
-              'ember-source': '~2.16.0'
+              'ember-source': '~2.16.0',
+              'ember-native-dom-event-dispatcher': '^0.6.4'
             }
           }
         },
@@ -22,7 +23,8 @@ module.exports = function() {
           name: 'ember-lts-2.18',
           npm: {
             devDependencies: {
-              'ember-source': '~2.18.0'
+              'ember-source': '~2.18.0',
+              'ember-native-dom-event-dispatcher': '^0.6.4'
             }
           }
         },

--- a/package-lock.json
+++ b/package-lock.json
@@ -4768,28 +4768,6 @@
         }
       }
     },
-    "ember-native-dom-event-dispatcher": {
-      "version": "0.6.4",
-      "resolved": "https://registry.npmjs.org/ember-native-dom-event-dispatcher/-/ember-native-dom-event-dispatcher-0.6.4.tgz",
-      "integrity": "sha512-b4BbEzxSzeIqcS9b1IA3Y8k6hWl0u0yZP3Ade1nNlQLpU213ifbece3iOi9VNdTFeX2I8sPIDHDivmJm7NoBZA==",
-      "dev": true,
-      "requires": {
-        "ember-cli-babel": "6.12.0",
-        "ember-cli-version-checker": "2.1.0"
-      },
-      "dependencies": {
-        "ember-cli-version-checker": {
-          "version": "2.1.0",
-          "resolved": "https://registry.npmjs.org/ember-cli-version-checker/-/ember-cli-version-checker-2.1.0.tgz",
-          "integrity": "sha512-ssiNyVTp+PphroFum8guHX9py4xU1PCxkRYgb25NxumgjpKTPjhkgTfpRRKXlIQe+/wVMmhf+Uv6w9vSLZKWKQ==",
-          "dev": true,
-          "requires": {
-            "resolve": "1.5.0",
-            "semver": "5.4.1"
-          }
-        }
-      }
-    },
     "ember-qunit": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/ember-qunit/-/ember-qunit-3.1.0.tgz",

--- a/package.json
+++ b/package.json
@@ -39,7 +39,6 @@
     "ember-cli-uglify": "^2.0.0",
     "ember-load-initializers": "^1.0.0",
     "ember-maybe-import-regenerator": "^0.1.6",
-    "ember-native-dom-event-dispatcher": "^0.6.4",
     "ember-resolver": "^4.0.0",
     "ember-route-action-helper": "2.0.0",
     "ember-source": "~3.0.0",


### PR DESCRIPTION
It simply makes way more explicit why ember-native-dom-event-dispatcher is needed in the first place and removes the warning that this addon should not be included in Ember 3.0 apps.