### PR TITLE
🔒 eliminate inline style

### DIFF
--- a/addon/components/file-upload/template.hbs
+++ b/addon/components/file-upload/template.hbs
@@ -1,2 +1,2 @@
-<input id={{for}} type="file" accept={{accept}} multiple={{multiple}} disabled={{disabled}} onchange={{action "change" value="target.files"}} style="display: none;">
+<input id={{for}} type="file" accept={{accept}} multiple={{multiple}} disabled={{disabled}} onchange={{action "change" value="target.files"}} hidden>
 {{yield queue}}

--- a/addon/styles/addon.css
+++ b/addon/styles/addon.css
@@ -1,0 +1,3 @@
+.file-upload input[hidden] {
+  display: none !important;
+}

--- a/addon/system/uuid.js
+++ b/addon/system/uuid.js
@@ -26,8 +26,8 @@ let random = (function () {
       }
 
       numbers[i] = r >>> ((i & 0x03) << 3) & 0xFF;
-      return numbers;
     }
+    return numbers;
   };
 })();
 

--- a/tests/unit/system/uuid-test.js
+++ b/tests/unit/system/uuid-test.js
@@ -11,13 +11,15 @@ module('uuid', function() {
     let uuid = module['default'];
 
     test(name + ' long', function (assert) {
-      assert.equal(uuid().length, 36);
-      assert.notEqual(uuid(), uuid());
+      assert.equal(uuid().length, 36, 'length');
+      assert.ok(/^[a-f\d]{8}-[a-f\d]{4}-[a-f\d]{4}-[a-f\d]{4}-[a-f\d]{12}$/.test(uuid()), 'looks like a full uuid');
+      assert.notEqual(uuid(), uuid(), 'each uuid is unique');
     });
 
     test(name + ' short', function (assert) {
-      assert.equal(uuid.short().length, 5);
-      assert.notEqual(uuid.short(), uuid.short());
+      assert.equal(uuid.short().length, 5, 'length');
+      assert.ok(/^[a-f\d]{5}$/.test(uuid.short()), 'looks like a short uuid');
+      assert.notEqual(uuid.short(), uuid.short(), 'each short uuid is unique');
     });
   };
 


### PR DESCRIPTION
Previously, `{{file-upload}}` would render an `<input>` with `style="display: none;"`.

A good [Content Security Policy](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy) will block inline styles.

This commit replaces `style="display: none;"` with `hidden`. The `[hidden]` attribute is an HTML5 standard. Browser support is [great](https://caniuse.com/#feat=hidden) on modern browsers.

Unfortunately, a rule as simple as
```css
input { display: block; }
```
will override the browser's default handling for `[hidden]`. (See [this jsfiddle](https://jsfiddle.net/j74ooj4b/).) For this reason, I added an `addon/styles/addon.css` with a powerful selector and rule to ensure the input stays hidden.