### PR TITLE
IE Drag & Drop Fix

### DIFF
--- a/addon/system/drag-listener.js
+++ b/addon/system/drag-listener.js
@@ -104,13 +104,17 @@ export default class {
 
   getDataTransferItemDetails(evt) {
     let itemDetails = [];
-    for (let i = 0; i < evt.dataTransfer.items.length; i++) {
-      let item = evt.dataTransfer.items[i];
-      itemDetails.push({
-        kind: item.kind,
-        type: item.type
-      });
+
+    if (evt.dataTransfer.items){
+      for (let i = 0; i < evt.dataTransfer.items.length; i++) {
+        let item = evt.dataTransfer.items[i];
+        itemDetails.push({
+          kind: item.kind,
+          type: item.type
+        });
+      }
     }
+
     return itemDetails;
   }
 

--- a/addon/system/drag-listener.js
+++ b/addon/system/drag-listener.js
@@ -85,7 +85,7 @@ export default class {
   findListener(evt) {
     return this._listeners.find(function ({ selector }) {
       let element = document.querySelector(selector);
-      return element === evt.target || element.contains(evt.target);
+      return element === evt.target || element.contains(evt.target) || evt.target.contains(element);
     });
   }
 


### PR DESCRIPTION
The first commit fixes an undefined or null reference caused by `DataTransferItemList` not being supported by the browser.  Affected browsers are IE and Safari.  https://developer.mozilla.org/en-US/docs/Web/API/DataTransferItemList

The second commit fixes an issue with `findListener` where the listener is attached to an `element` on a child of the `evt.target`.

Related Issues:
https://github.com/tim-evans/ember-file-upload/issues/136, https://github.com/tim-evans/ember-file-upload/issues/141