### PR TITLE
Fix testing example

### DIFF
--- a/tests/dummy/app/templates/docs/testing.md
+++ b/tests/dummy/app/templates/docs/testing.md
@@ -8,8 +8,8 @@
 import { upload } from 'ember-file-upload/mirage';
 
 export default function () {
-  this.post('/photos/new', upload(function (db, file) {
-    let { name: filename, size: filesize, url } = file;
+  this.post('/photos/new', upload(function (db, request) {
+    let { name: filename, size: filesize, url } = request.requestBody.file;
     let photo = db.create('photo', { filename, filesize, url, uploadedAt: new Date() });
     return photo;
   }));


### PR DESCRIPTION
Update testing example to fix the correct signature of the mirage `upload` helper's callback.

The callback receives the `request`, not directly the `file` here: https://github.com/tim-evans/ember-file-upload/blob/latest/addon/mirage/index.js#L56

Great addon btw! 👍