### PR TITLE
Fix for- Dropzone triggering events out of scope->which should not #177

### DIFF
--- a/addon/system/drag-listener.js
+++ b/addon/system/drag-listener.js
@@ -85,7 +85,7 @@ export default class {
   findListener(evt) {
     return this._listeners.find(function ({ selector }) {
       let element = document.querySelector(selector);
-      return element === evt.target || element.contains(evt.target) || evt.target.contains(element);
+      return element === evt.target || element.contains(evt.target);
     });
   }
 


### PR DESCRIPTION
Removed 'evt.target.contains(element)' as it always finds the element and triggers the drag events.