### PR TITLE
Adds support for additional SVG tags

### DIFF
--- a/addon/components/file-upload/component.js
+++ b/addon/components/file-upload/component.js
@@ -183,7 +183,7 @@ if (DEBUG) {
     'noscript', 'object', 'q', 'radialGradient', 'rect', 'ruby', 'samp', 
     'script', 'small', 'span', 'strong', 'sub', 'sup', 'svg', 'time', 'var', 
     'video', 'wbr', 'path', 'polygon', 'polyline', 
-    'g', 'use', 'circle'];
+    'g', 'use'];
 
   component.reopen({
     didInsertElement() {

--- a/addon/components/file-upload/component.js
+++ b/addon/components/file-upload/component.js
@@ -177,12 +177,12 @@ const component = Component.extend({
 });
 
 if (DEBUG) {
-  const VALID_TAGS = ['a', 'abbr', 'area', 'audio', 'b', 'bdo', 'br', 'canvas', 
-    'cite', 'circle', 'clipPath', 'code', 'command', 'datalist', 'del', 'dfn', 
-    'em', 'embed', 'i', 'iframe', 'img', 'kbd', 'line', 'mark', 'mask', 'math', 
-    'noscript', 'object', 'q', 'radialGradient', 'rect', 'ruby', 'samp', 
-    'script', 'small', 'span', 'strong', 'sub', 'sup', 'svg', 'time', 'var', 
-    'video', 'wbr', 'path', 'polygon', 'polyline', 
+  const VALID_TAGS = ['a', 'abbr', 'area', 'audio', 'b', 'bdo', 'br', 'canvas',
+    'cite', 'circle', 'clipPath', 'code', 'command', 'datalist', 'del', 'dfn',
+    'em', 'embed', 'i', 'iframe', 'img', 'kbd', 'line', 'mark', 'mask', 'math',
+    'noscript', 'object', 'q', 'radialGradient', 'rect', 'ruby', 'samp',
+    'script', 'small', 'span', 'strong', 'sub', 'sup', 'svg', 'time', 'var',
+    'video', 'wbr', 'path', 'polygon', 'polyline',
     'g', 'use'];
 
   component.reopen({

--- a/addon/components/file-upload/component.js
+++ b/addon/components/file-upload/component.js
@@ -177,12 +177,13 @@ const component = Component.extend({
 });
 
 if (DEBUG) {
-  const VALID_TAGS = ['a', 'abbr', 'area', 'audio', 'b', 'bdo', 'br', 'canvas', 'cite',
-    'code', 'command', 'datalist', 'del', 'dfn', 'em', 'embed', 'i',
-    'iframe', 'img', 'kbd', 'mark', 'math', 'noscript', 'object', 'q',
-    'ruby', 'samp', 'script', 'small', 'span', 'strong', 'sub', 'sup',
-    'svg', 'time', 'var', 'video', 'wbr',
-    'path', 'g', 'use', 'circle'];
+  const VALID_TAGS = ['a', 'abbr', 'area', 'audio', 'b', 'bdo', 'br', 'canvas', 
+    'cite', 'circle', 'clipPath', 'code', 'command', 'datalist', 'del', 'dfn', 
+    'em', 'embed', 'i', 'iframe', 'img', 'kbd', 'line', 'mark', 'mask', 'math', 
+    'noscript', 'object', 'q', 'radialGradient', 'rect', 'ruby', 'samp', 
+    'script', 'small', 'span', 'strong', 'sub', 'sup', 'svg', 'time', 'var', 
+    'video', 'wbr', 'path', 'polygon', 'polyline', 
+    'g', 'use', 'circle'];
 
   component.reopen({
     didInsertElement() {


### PR DESCRIPTION
Adds additional SVG tags to the VALID_TAGS constant:

• circle
• clipPath
• line
• mask
• radialGradient
• rect
• polygon
• polyline