### PR TITLE
Update acceptance test example to follow RFC-232

### DIFF
--- a/README.md
+++ b/README.md
@@ -164,23 +164,27 @@ export default function () {
 
 ```javascript
 import { upload } from 'ember-file-upload/test-support';
+import { module } from 'qunit';
+import { setupApplicationTest } from 'ember-qunit';
 
-moduleForAcceptance('/photos');
+module('/photos', function(hooks) {
+  setupApplicationTest(hooks);
 
-test('uploading an image', async function (assert) {
-  let data = new Uint8Array([
-    137,80,78,71,13,10,26,10,0,0,0,13,73,72,68,82,0,0,0,8,0,0,
-    0,8,8,2,0,0,0,75,109,41,220,0,0,0,34,73,68,65,84,8,215,99,120,
-    173,168,135,21,49,0,241,255,15,90,104,8,33,129,83,7,97,163,136,
-    214,129,93,2,43,2,0,181,31,90,179,225,252,176,37,0,0,0,0,73,69,
-    78,68,174,66,96,130
-  ]);
+  test('uploading an image', async function (assert) {
+    let data = new Uint8Array([
+      137,80,78,71,13,10,26,10,0,0,0,13,73,72,68,82,0,0,0,8,0,0,
+      0,8,8,2,0,0,0,75,109,41,220,0,0,0,34,73,68,65,84,8,215,99,120,
+      173,168,135,21,49,0,241,255,15,90,104,8,33,129,83,7,97,163,136,
+      214,129,93,2,43,2,0,181,31,90,179,225,252,176,37,0,0,0,0,73,69,
+      78,68,174,66,96,130
+    ]);
 
-  let photo = new File([data], 'image.png', { type: 'image/png'});
-  await upload('#upload-photo', photo);
+    let photo = new File([data], 'image.png', { type: 'image/png'});
+    await upload('#upload-photo', photo);
 
-  let uploadedPhoto = server.db.photos[0];
-  assert.equal(uploadedPhoto.name, 'image.png');
+    let uploadedPhoto = server.db.photos[0];
+    assert.equal(uploadedPhoto.name, 'image.png');
+  });
 });
 ```
 
@@ -188,14 +192,18 @@ If the file isn't uploaded to the server, you don't need to use the mirage helpe
 
 ```javascript
 import { upload } from 'ember-file-upload/test-support';
+import { module } from 'qunit';
+import { setupApplicationTest } from 'ember-qunit';
 
-moduleForAcceptance('/notes');
+module('/notes', function(hooks) {
+  setupApplicationTest(hooks);
 
-test('showing a note', async function (assert) {
-  let file = new File(["I can feel the money leaving my body"], 'douglas_coupland.txt', { type: 'text/plain'});
-  await upload('#upload-note', file);
+  test('showing a note', async function (assert) {
+    let file = new File(["I can feel the money leaving my body"], 'douglas_coupland.txt', { type: 'text/plain'});
+    await upload('#upload-note', file);
 
-  assert.equal(find('.note').text(), 'I can feel the money leaving my body');
+    assert.equal(find('.note').text(), 'I can feel the money leaving my body');
+  });
 });
 ```
 

--- a/tests/dummy/app/templates/docs/testing.md
+++ b/tests/dummy/app/templates/docs/testing.md
@@ -19,16 +19,20 @@ export default function () {
 ```javascript
 import { upload } from 'ember-file-upload/test-support';
 import File from 'ember-file-upload/file';
+import { module } from 'qunit';
+import { setupApplicationTest } from 'ember-qunit';
 
-moduleForAcceptance('/photos');
+module('/photos', function(hooks) {
+  setupApplicationTest(hooks);
 
-test('uploading an image', async function (assert) {
-  let file = File.fromDataURL('data:image/gif;base64,R0lGODdhCgAKAIAAAAEBAf///ywAAAAACgAKAAACEoyPBhp7vlySqVVFL8oWg89VBQA7');
+  test('uploading an image', async function (assert) {
+    let file = File.fromDataURL('data:image/gif;base64,R0lGODdhCgAKAIAAAAEBAf///ywAAAAACgAKAAACEoyPBhp7vlySqVVFL8oWg89VBQA7');
 
-  await upload('#upload-photo', file, 'smile.gif');
+    await upload('#upload-photo', file, 'smile.gif');
 
-  let photo = server.db.photos[0];
-  assert.equal(photo.filename, 'smile.gif');
+    let photo = server.db.photos[0];
+    assert.equal(photo.filename, 'smile.gif');
+  });
 });
 ```
 
@@ -36,14 +40,18 @@ If the file isn't uploaded to the server, you don't need to use the mirage helpe
 
 ```javascript
 import { upload } from 'ember-file-upload/test-support';
+import { module } from 'qunit';
+import { setupApplicationTest } from 'ember-qunit';
 
-moduleForAcceptance('/notes');
+module('/notes', function(hooks) {
+  setupApplicationTest(hooks);
 
-test('showing a note', async function (assert) {
-  let file = File.fromDataURL('data:text/plain;base64,SSBjYW4gZmVlbCB0aGUgbW9uZXkgbGVhdmluZyBteSBib2R5');
+  test('showing a note', async function (assert) {
+    let file = File.fromDataURL('data:text/plain;base64,SSBjYW4gZmVlbCB0aGUgbW9uZXkgbGVhdmluZyBteSBib2R5');
 
-  await upload('#upload-note', file, 'douglas_coupland.txt');
+    await upload('#upload-note', file, 'douglas_coupland.txt');
 
-  assert.equal(find('.note').text(), 'I can feel the money leaving my body');
+    assert.equal(find('.note').text(), 'I can feel the money leaving my body');
+  });
 });
 ```


### PR DESCRIPTION
Just to keep in sync what's reflect in Ember.js guides since v3.0.